### PR TITLE
fix(toolkits ng-pro, pro, vue-pro): add tmplate/.npmignore file

### DIFF
--- a/packages/toolkits/ng-pro/template/root/.npmignore
+++ b/packages/toolkits/ng-pro/template/root/.npmignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/packages/toolkits/pro/template/tinyng/.npmignore
+++ b/packages/toolkits/pro/template/tinyng/.npmignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/packages/toolkits/pro/template/tinyvue/.npmignore
+++ b/packages/toolkits/pro/template/tinyvue/.npmignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/packages/toolkits/vue-pro/template/root/.npmignore
+++ b/packages/toolkits/vue-pro/template/root/.npmignore
@@ -1,0 +1,1 @@
+!.gitignore


### PR DESCRIPTION
fix #6

# PR
## description
修复 tiny init 生成的项目模板没有.gitignore文件的问题

## reason of issue
npm发布时会默认忽略发布.gitignore文件，因此 [@opentiny/tiny-toolkit-ng-pro](https://www.npmjs.com/package/@opentiny/tiny-toolkit-ng-pro?activeTab=code)、[@opentiny/tiny-toolkit-vue-pro](https://www.npmjs.com/package/@opentiny/tiny-toolkit-vue-pro?activeTab=code) 中没有`template/root/.gitignore`文件

## how to fix
在template/root目录下添加.npmignore文件，配置 "!.gitignore"，发布`template/root/.gitignore`文件

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-cli/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
发布的npm包（[@opentiny/tiny-toolkit-ng-pro](https://www.npmjs.com/package/@opentiny/tiny-toolkit-ng-pro?activeTab=code)、[@opentiny/tiny-toolkit-vue-pro](https://www.npmjs.com/package/@opentiny/tiny-toolkit-vue-pro?activeTab=code)）中**没有**`template/root/.gitignore`文件，因此 tiny init vue-pro, tiny init ng-pro 生成的模板**没有**.gitignore文件

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 6

## What is the new behavior?
发布npm包（[@opentiny/tiny-toolkit-ng-pro](https://www.npmjs.com/package/@opentiny/tiny-toolkit-ng-pro?activeTab=code)、[@opentiny/tiny-toolkit-vue-pro](https://www.npmjs.com/package/@opentiny/tiny-toolkit-vue-pro?activeTab=code)）中的**会包含**`template/root/.gitignore`文件，因此
tiny init vue-pro, tiny init ng-pro 生成的模板**会包含**.gitignore文件
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
To see what will be included in your package, run `npx npm-packlist`. All files are included by default, with the following exceptions: https://docs.npmjs.com/cli/v9/commands/npm-publish

Certain files that are relevant to package installation and distribution are always included. For example, package.json, README.md, LICENSE, and so on.

If there is a "files" list in [package.json](https://docs.npmjs.com/cli/v9/configuring-npm/package-json), then only the files specified will be included. (If directories are specified, then they will be walked recursively and their contents included, subject to the same ignore rules.)

If there is a .gitignore or .npmignore file, then ignored files in that and all child directories will be excluded from the package. If both files exist, then the .gitignore is ignored, and only the .npmignore is used.

.npmignore files follow the [same pattern rules](https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring) as .gitignore files

If the file matches certain patterns, then it will never be included, unless explicitly added to the "files" list in package.json, or un-ignored with a ! rule in a .npmignore or .gitignore file.

Symbolic links are never included in npm packages.

