### PR TITLE
fix(commands): 修复套件名称获取错误的问题

### DIFF
--- a/packages/cli/commands/src/init.ts
+++ b/packages/cli/commands/src/init.ts
@@ -94,7 +94,7 @@ async function getName() {
 }
 
 export default async function (args: string[]) {
-  let name = args.pop() || '';
+  let name = args.shift() || '';
   const intl = new Intl(message);
   if (!name) {
     // 未传入套件名,提示并列出可用套件名


### PR DESCRIPTION
fix #28

# PR
修复套件名称获取错误的问题，详见：https://github.com/opentiny/tiny-cli/issues/28

**根因**: 
解析命令时将最后一个命令作为了套件名称

**处理措施**: 
将`init`命令后的第一个命令作为套件名称

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-cli/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

解析命令时将最后一个命令作为了套件名称

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 28

## What is the new behavior?

将`init`命令后的第一个命令作为套件名称
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
